### PR TITLE
Add configurability via .pronto-bundler_audit.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,32 @@ Tested MRI Ruby Versions:
 
 ## Usage
 
-Once installed as a gem, this runner activate automatically when [running Pronto](https://github.com/prontolabs/pronto#usage) -- no configuration is required.
+Once installed as a gem, this runner activates automatically when [running Pronto](https://github.com/prontolabs/pronto#usage) -- no configuration is required.
 
-Note: Unlike most Pronto runners, pronto-bundler_audit will always scan Gemfile.lock whenever Pronto is run. That is, this runner does not only run against patches/diffs made on Gemfile.lock. The point is to find issues/advisories on every Pronto run, not just when Gemfile.lock has been updated. Because that wouldn't really help us find vulnerabilities in a project's gems in a timely fashion.
+Note: Unlike most Pronto runners, pronto-bundler_audit will always scan Gemfile.lock whenever Pronto is run. That is, this runner does not only run against patches/diffs made on Gemfile.lock. The point is to find issues/advisories on every Pronto run, not just when Gemfile.lock has been updated. Because, otherwise, this gem  wouldn't really help us find vulnerabilities in a project's gems in a timely fashion.
 
-### Examples
+## Configuration
 
-#### Local Pronto Run
+Configuration of the pronto-bundler_audit gem is available by creating a YAML file on the project root, called `.pronto-bundler_audit.yml`.
 
-##### Compact Mode
+Available configuration options include:
+
+```yaml
+Advisories:
+  # Send the following advisory names to bundler_audit's `ignored` option.
+  Ignore:
+    - CVE-YYYY-####1
+    - CVE-YYYY-####2
+```
+
+The above acts the same as running `bundle-audit check --ignore CVE-YYYY-####1 CVE-YYYY-####2`.
+
+
+## Examples
+
+### Local Pronto Run
+
+#### Compact Mode
 
 ```bash
 $ pronto run -c=master --runner bundler_audit
@@ -49,7 +66,7 @@ Running Pronto::BundlerAudit
 Gemfile.lock: E: Gem: bootstrap-sass v3.4.0 | Medium Advisory: XSS vulnerability in bootstrap-sass -- CVE-2019-8331 (https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/) | Solution: Upgrade to >= 3.4.1.
 ```
 
-##### Verbose Mode
+#### Verbose Mode
 
 ```bash
 $ pronto run -c=master --runner bundler_audit
@@ -74,11 +91,11 @@ Solution: Upgrade to >= 3.4.1.
 
 #### Github Pull Request - Comments
 
-##### Verbose Mode
+#### Verbose Mode
 
 ![Github Comment - Verbose](images/github-comment-verbose.png)
 
-##### Compact Mode
+#### Compact Mode
 
 Note: Not yet available by configuration.
 

--- a/lib/formatter/github_pull_request_review_formatter.rb
+++ b/lib/formatter/github_pull_request_review_formatter.rb
@@ -3,7 +3,9 @@ module Pronto
     # Pronto::Formatter::GithubPullRequestReviewFormatter comes from the
     # Pronto gem itself.
     #
-    # The methods below are a feature overrides to:
+    # # Note: Ignore `method redefined` warnings on these methods.
+    #
+    # The methods below are feature overrides to:
     #   1. prevent the {#line_number} class from failing if none of the patches
     #      contain the `message.line.new_lineno` value found. Which can happen
     #      in the context of this pronto-bundler audit gem since we aren't

--- a/lib/pronto/bundler_audit.rb
+++ b/lib/pronto/bundler_audit.rb
@@ -17,6 +17,10 @@ module Pronto
   class BundlerAudit < ::Pronto::Runner
     GEMFILE_LOCK_FILENAME = "Gemfile.lock"
 
+    def self.configuration
+      @configuration ||= Pronto::BundlerAudit::Configuration.new
+    end
+
     # @return [Array<Pronto::Message>] one for each issue found
     def run
       results = Auditor.call
@@ -42,6 +46,7 @@ module Pronto
   end
 end
 
+require "pronto/bundler_audit/configuration"
 require "pronto/bundler_audit/version"
 require "pronto/bundler_audit/auditor"
 require "pronto/bundler_audit/results/pronto_messages_adapter"

--- a/lib/pronto/bundler_audit/configuration.rb
+++ b/lib/pronto/bundler_audit/configuration.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Pronto
+  class BundlerAudit
+    # Pronto::BundlerAudit::Configuration loads configuration for the
+    # pronto-bundler_audit gem from the `.pronto-bundler_audit.yml` file and
+    # provides service methods for reading configuration settings.
+    class Configuration
+      def initialize(path: ".pronto-bundler_audit.yml")
+        @config_file_path = path
+      end
+
+      # @return [Array<Sring>] the Advisory Names for bundler_audit to ignore
+      def ignored_advisories
+        configuration.dig("Advisories", "Ignore")
+      end
+
+      private
+
+      def configuration
+        @configuration ||=
+          if File.exist?(@config_file_path)
+            YAML.load(configuration_file.read)
+          else
+            {}
+          end
+      end
+
+      def configuration_file
+        File.open(@config_file_path)
+      end
+    end
+  end
+end

--- a/lib/pronto/bundler_audit/scanner.rb
+++ b/lib/pronto/bundler_audit/scanner.rb
@@ -2,6 +2,7 @@
 
 require_relative "results/insecure_source"
 require_relative "results/unpatched_gem"
+require "yaml"
 
 module Pronto
   class BundlerAudit
@@ -32,14 +33,19 @@ module Pronto
 
       # Invoke the 3rd-party bundler-audit Gem.
       #
+      # @param ignore_advisories [Array<String>] the advisories to be ignored
+      #   by the bundler_audit scan
+      #
       # @return [Array] if insecure sources are found or if gems with an
       #   advisory are found, the Array will contain
       #   ::Bundler::Audit::Scanner::InsecureSource
       #   or ::Bundler::Audit::Scanner::UnpatchedGem objects, respectively.
       #     - Bundler::Audit::Scanner::InsecureSource = Struct.new(:source)
       #     - Bundler::Audit::Scanner::UnpatchedGem = Struct.new(:gem, :advisory)
-      def run_scanner
-        ::Bundler::Audit::Scanner.new.scan
+      def run_scanner(
+            ignored_advisories:
+              Pronto::BundlerAudit.configuration.ignored_advisories)
+        ::Bundler::Audit::Scanner.new.scan(ignore: ignored_advisories)
       end
 
       # Convert the passed in `scan_result` class/value into a local Results::*

--- a/test/fixtures/.test-pronto-bundler_audit.yml
+++ b/test/fixtures/.test-pronto-bundler_audit.yml
@@ -1,0 +1,5 @@
+Advisories:
+  # Send the following advisory names to bundler_audit's `ignored` option.
+  Ignore:
+    - CVE-YYYY-####1
+    - CVE-YYYY-####2

--- a/test/pronto/bundler_audit/configuration_test.rb
+++ b/test/pronto/bundler_audit/configuration_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Pronto::BundlerAudit::ConfigurationTest < Minitest::Spec
+  describe "Pronto::BundlerAudit::Configuration" do
+    let(:base_klazz) { Pronto::BundlerAudit }
+    let(:klazz) { base_klazz::Configuration }
+
+    let(:config_file_path) { "test/fixtures/.test-pronto-bundler_audit.yml" }
+
+    describe "#ignored_advisories" do
+      context "GIVEN a Configuration File that exists" do
+        context "GIVEN Advisories -> Ignore entries are present" do
+          subject { klazz.new(path: config_file_path) }
+
+          it "returns the expected Array" do
+            value(subject.ignored_advisories).must_equal(%w[
+              CVE-YYYY-####1
+              CVE-YYYY-####2
+            ])
+          end
+        end
+      end
+
+      context "GIVEN a Configuration File that doesn't exist" do
+        subject { klazz.new(path: "non_existent_config_file.yml") }
+
+        it "returns nil" do
+          value(subject.ignored_advisories).must_be_nil
+        end
+      end
+    end
+  end
+end

--- a/test/pronto/bundler_audit/scanner_test.rb
+++ b/test/pronto/bundler_audit/scanner_test.rb
@@ -84,7 +84,7 @@ class Pronto::BundlerAudit::ScannerTest < Minitest::Spec
   end
 
   class FakeInsecureSourceBundlerAuditScanner
-    def scan
+    def scan(*)
       [Bundler::Audit::Scanner::InsecureSource.new]
     end
   end
@@ -99,7 +99,7 @@ class Pronto::BundlerAudit::ScannerTest < Minitest::Spec
   end
 
   class FakeUnpatchedGemBundlerAuditScanner
-    def scan
+    def scan(*)
       [Bundler::Audit::Scanner::UnpatchedGem.new]
     end
   end
@@ -114,7 +114,7 @@ class Pronto::BundlerAudit::ScannerTest < Minitest::Spec
   end
 
   class FakeUnknownBundlerAuditScanner
-    def scan
+    def scan(*)
       [FakeUnknownResultType.new]
     end
   end


### PR DESCRIPTION
Feature Request: https://github.com/pdobb/pronto-bundler_audit/issues/6

pronto-bundler_audit will now look for a file in the project root called
`.pronto-bundler_audit.yml` and, if present, draw configuration options
from it.

For now, the only configuration available is, e.g.:

```yaml
Advisories:
  # Send the following advisory names to bundler_audit's `ignored` option.
  Ignore:
    - CVE-YYYY-####1
    - CVE-YYYY-####2
```

The above acts the same as running
`bundle-audit check --ignore CVE-YYYY-####1 CVE-YYYY-####2`.

Also:
- Fix up wording in the README a bit
- Fix up heading levels in the README